### PR TITLE
Add a new method to get country and city name for a given IANA time zone identifier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.suo
 *.user
 *.sln.docstates
+.vscode/
 
 # Build results
 [Dd]ebug/

--- a/README.md
+++ b/README.md
@@ -82,6 +82,49 @@ abbreviations.Daylight == "CEST"
 localized correctly for every time zone.  In most cases, you should use abbreviations
 for end-user display output only.  Do not attempt to use abbreviations when parsing input.
 
+### GetLocationNamesForTimeZone
+
+Get the countr(ies) and city name representative of an IANA time zone ID.  This can
+be useful when displaying a user interface showing a previously selected time zone,
+or allowing selection between two time zones that have the same name, when the
+selectable time zones are not based on a selected country.
+
+Note that a single time zone identifier may have multiple countries but will only
+have a single city; specifically, the one referred to within the IANA identifier itself.
+Note also that some time zones have _no_ representative countries; for example the
+adminstrative time zones (those starting with "Etc/").  These will return a an empty
+array for `Country` and a value for `City` which is derived from the time zone
+identifier.  In practice these time zones are not ambiguous and thus do not need
+additional country/city information.
+
+```csharp
+// These two time zones have the same name, so a user would have difficulty
+// selecting between them in a user interface.
+var tz1 = TZNames.GetNamesForTimeZone("America/Tijuana", "en-US");
+var tz2 = TZNames.GetNamesForTimeZone("America/Los_Angeles", "en-US");
+Assert.Equal(tz1.Generic, tz2.Generic); // "Pacific Time"
+
+// They can be differentiated for the user by showing the countr(ies)
+// and/or city associated with each one
+var loc1 = TZNames.GetLocationNamesForTimeZone("America/Tijuana", "en-US");
+var loc2 = TZNames.GetLocationNamesForTimeZone("America/Los_Angeles", "en-US");
+
+// An example of a time zone with multiple countries
+var loc3 = TZNames.GetLocationNamesForTimeZone("Atlantic/St_Helena", "en-US");
+
+// An example of a time zone with no countries
+var loc4 = TZNames.GetLocationNamesForTimeZone("Etc/UTC", "en-US");
+```
+*Output*
+
+Input               | Countries                                      | City
+--------------------|------------------------------------------------|----------
+America/Tijuana     | Mexico                                         | Tijuana
+America/Los_Angeles | United States                                  | Los Angeles
+Atlantic/St_Helena  | St. Helena, Ascension Island, Tristan da Cunha | St Helena
+Etc/UTC             | _[empty list]_                                 | UTC
+
+
 ## Methods for listing time zones
 
 ### GetTimeZonesForCountry

--- a/src/TimeZoneNames/TimeZoneLocationNames.cs
+++ b/src/TimeZoneNames/TimeZoneLocationNames.cs
@@ -1,0 +1,23 @@
+namespace TimeZoneNames
+{
+    /// <summary>
+    /// Represents the names of the time zone location (country and city).
+    /// </summary>
+    public class TimeZoneLocationNames
+    {
+        /// <summary>
+        /// The name(s) of the representative countries.
+        /// 
+        /// Note: this may be an empty array but will never be null.
+        /// </summary>
+        public string[] Countries { get; set; }
+
+        /// <summary>
+        /// The name of the representative city.
+        ///
+        /// This is guaranteed not to be `null`, though the response for some
+        /// time zones ("Etc/*" for example) may not actually be a city name.
+        /// </summary>
+        public string City { get; set; }
+    }
+}

--- a/test/TimeZoneNames.Tests/TimeZoneCountriesTests.cs
+++ b/test/TimeZoneNames.Tests/TimeZoneCountriesTests.cs
@@ -323,5 +323,42 @@ namespace TimeZoneNames.Tests
                 _output.WriteLine("");
             }
         }
+
+        [Fact]
+        public void Can_Get_Country_And_City_For_All_Zones_In_All_Countries()
+        {
+            var locale = "en-US";
+
+            var countries = TZNames.GetCountryNames(locale);
+            foreach (var country in countries)
+            {
+                _output.WriteLine("{0} : {1}", country.Key, country.Value);
+                _output.WriteLine("------------------------------------------------------------");
+                var zones = TZNames.GetTimeZoneIdsForCountry(country.Key);
+                foreach (var zone in zones)
+                {
+                    var names = TZNames.GetLocationNamesForTimeZone(zone, locale);
+                    _output.WriteLine($"{zone.PadRight(30)} {string.Join(",",names.Countries).PadRight(30)} {names.City.PadRight(30)}");
+                    Assert.Contains(country.Value, names.Countries);
+                }
+
+                _output.WriteLine("");
+            }
+        }
+
+        [Fact]
+        public void Can_Get_Country_And_City_For_All_Fixed_Zones()
+        {
+            var locale = "en-US";
+
+            var zones = TZNames.GetFixedTimeZoneIds();
+            foreach (var zone in zones)
+            {
+                var names = TZNames.GetLocationNamesForTimeZone(zone, locale);
+                _output.WriteLine($"{zone.PadRight(30)} {string.Join(",",names.Countries).PadRight(30)} {names.City.PadRight(30)}");
+            }
+
+            _output.WriteLine("");
+        }
     }
 }


### PR DESCRIPTION
I have a need to accept IANA time zones as both input and output within my application.  It is not practical for me to change the interfaces to accept country and time zone independently.  Moreover, on output, I have a time zone identifier but can't disambiguate it (I.e. if I have "America/Tijuana" or "America/Los_Angeles" I have to show the user more than just "Pacific Time").

I added a new method, GetLocationNamesForTimeZone, which takes as input the IANA time zone ID, and outputs the list of countries and the "representative" city for the time zone.  Also added readme documentation and tests to show how it works.