### PR TITLE
Avoid closure in delegate

### DIFF
--- a/src/TimeZoneNames/TZNames.cs
+++ b/src/TimeZoneNames/TZNames.cs
@@ -280,7 +280,7 @@ namespace TimeZoneNames
         {
             return Comparers.GetOrAdd(langKey, key =>
             {
-                var culture = new CultureInfo(langKey.Replace('_', '-'));
+                var culture = new CultureInfo(key.Replace('_', '-'));
                 return StringComparer.Create(culture, true);
             });
         }


### PR DESCRIPTION
Instead of creating a closure over `langKey` we can use the provided `key`.