### PR TITLE
Bugfix: IANA time zone identifier causes exception in xamarin app

### DIFF
--- a/src/TimeZoneNames/TZNames.cs
+++ b/src/TimeZoneNames/TZNames.cs
@@ -427,7 +427,7 @@ public static class TZNames
                 timeZoneId = TZConvert.WindowsToIana(timeZoneId);
             }
         }
-        catch
+        catch(TimeZoneNotFoundException)
         {
         }
 

--- a/src/TimeZoneNames/TZNames.cs
+++ b/src/TimeZoneNames/TZNames.cs
@@ -420,9 +420,15 @@ public static class TZNames
 
     private static TimeZoneValues GetNames(string timeZoneId, string languageKey, bool abbreviations)
     {
-        if (TZConvert.KnownWindowsTimeZoneIds.Contains(timeZoneId, StringComparer.OrdinalIgnoreCase))
+        try
         {
-            timeZoneId = TZConvert.WindowsToIana(timeZoneId);
+            if (TZConvert.KnownWindowsTimeZoneIds.Contains(timeZoneId, StringComparer.OrdinalIgnoreCase))
+            {
+                timeZoneId = TZConvert.WindowsToIana(timeZoneId);
+            }
+        }
+        catch
+        {
         }
 
         timeZoneId = GetCldrCanonicalId(timeZoneId);


### PR DESCRIPTION
_Pull request is somewhat related to #47._
I'm currnetly working on a Xamarin Forms app, where I had to implement time zone picker. I require localization, and I found that this library suits my needs well, but I ran into an issue. Since in phones time zones Ids are in IANA format, when I call `TZNames.GetTimeZonesForCountry` method, exception of type `System.TimeZoneNotFoundException` is thrown, since IANA Id cannot be found in `TZConvert.KnownWindowsTimeZoneIds`. I decided to copy project files into my project and try this fix, and it solves this problem. It also presumes library logic, since if the name was not found in that collection, it is already in correct format. It also does not break test run.