### PR TITLE
Fix issue with expected format of language code

### DIFF
--- a/src/TimeZoneNames/TZNames.cs
+++ b/src/TimeZoneNames/TZNames.cs
@@ -375,7 +375,7 @@ public static class TZNames
             {
                 var keys = forDisplayNames ? (IEnumerable<string>) Data.DisplayNames.Keys : Data.CldrLanguageData.Keys;
                 key = keys.FirstOrDefault(x =>
-                    x.Split('_')[0].Equals(languageCode.Split('_')[0], StringComparison.OrdinalIgnoreCase));
+                    x.Split('_')[0].Equals(languageCode.Split('-')[0], StringComparison.OrdinalIgnoreCase));
 
                 if (key == null)
                 {

--- a/test/TimeZoneNames.Tests/DisplayNamesTests.cs
+++ b/test/TimeZoneNames.Tests/DisplayNamesTests.cs
@@ -101,7 +101,7 @@ public class DisplayNamesTests
         var errors = new List<string>();
         foreach (var id in TZConvert.KnownWindowsTimeZoneIds)
         {
-            var displayName = TZNames.GetDisplayNameForTimeZone(id, "en");
+            var displayName = TZNames.GetDisplayNameForTimeZone(id, "en-AU");
             if (string.IsNullOrEmpty(displayName))
             {
                 errors.Add(id);


### PR DESCRIPTION
The format of the language code is [language]-[country] but this method is trying to split it based on a format of [language]_[country]

I also updated one of the tests to have one of the failing test cases so we can ensure this doesn't break in the future.

Before:
![MicrosoftTeams-image (27)](https://github.com/mattjohnsonpint/TimeZoneNames/assets/24326190/cccb3724-d86b-4579-ace4-4a2cf622748a)
After:
![MicrosoftTeams-image (28)](https://github.com/mattjohnsonpint/TimeZoneNames/assets/24326190/d540bf92-6a50-407d-8c98-c6dd8988df7d)
