### PR TITLE
feat: deprecate GetAbbreviationsForTimeZone

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ Read [this blog post](https://codeofmatt.com/localized-time-zone-names-in-net/) 
 Note that if you are running .NET 6+ on Linux or macOS, the built-in names now stem from ICU and thus this library is no longer needed.
 See [the .NET blog post](https://devblogs.microsoft.com/dotnet/date-time-and-time-zone-enhancements-in-net-6/#time-zone-display-names-on-linux-and-macos) for more details.
 
+**NOTE**:
+Methods for retrieving localized time zone abbreviations have been deprecated, as the source data for abbreviations is generally unreliable.
+
 Nuget Installation
 =============================================================================
 ```powershell
@@ -61,29 +64,6 @@ names.Generic == "Central European Time"
 names.Standard == "Central European Standard Time"
 names.Daylight == "Central European Summer Time"
 ```
-
-### GetAbbreviationsForTimeZone
-Look up the localized abbreviations for a specific time zone:
-```csharp
-var abbreviations = TZNames.GetAbbreviationsForTimeZone("America/Los_Angeles", "en-US");
-
-abbreviations.Generic == "PT"
-abbreviations.Standard == "PST"
-abbreviations.Daylight == "PDT"
-```
-
-You can pass a Windows time zone id instead, if you like:
-```csharp
-var abbreviations = TZNames.GetAbbreviationsForTimeZone("Romance Standard Time", "en-GB");
-
-names.Generic == "CET"
-abbreviations.Standard == "CET"
-abbreviations.Daylight == "CEST"
-```
-
-**Note:** Time zone abbreviations are sometimes inconsistent, and are not necessarily
-localized correctly for every time zone.  In most cases, you should use abbreviations
-for end-user display output only.  Do not attempt to use abbreviations when parsing input.
 
 ## Methods for listing time zones
 
@@ -246,7 +226,7 @@ TODO: Add examples for this method.
 
 ### GetFixedTimeZoneAbbreviations
 
-Gets the same list of zones as `GetFixedTimeZoneIds`, but includes localized abbreviations.
+Gets the same list of zones as `GetFixedTimeZoneIds`, but includes abbreviations.
 
 TODO: Add examples for this method.
 

--- a/src/TimeZoneNames/TZNames.cs
+++ b/src/TimeZoneNames/TZNames.cs
@@ -210,6 +210,7 @@ public static class TZNames
     /// <param name="timeZoneId">An IANA or Windows time zone identifier.</param>
     /// <param name="languageCode">The IETF language tag (culture code) to use when localizing the abbreviations.</param>
     /// <returns>A <see cref="TimeZoneValues"/> object containing the localized generic, standard, and daylight abbreviations.</returns>
+    [Obsolete("WARNING! Time zone abbreviations are inconsistent and not well-defined in the source data.  This method will be removed in a future release.")]
     public static TimeZoneValues GetAbbreviationsForTimeZone(string timeZoneId, string languageCode)
     {
         var langKey = GetLanguageKey(languageCode);
@@ -217,7 +218,7 @@ public static class TZNames
         {
             throw new ArgumentException("Invalid Language Code", nameof(languageCode));
         }
-        
+
         if (TZConvert.TryWindowsToIana(timeZoneId, out var ianaId))
         {
             timeZoneId = ianaId;
@@ -298,7 +299,7 @@ public static class TZNames
         {
             throw new ArgumentException("Invalid Language Code", nameof(languageCode));
         }
-        
+
         var displayNames = Data.DisplayNames[langKey]
             .Where(x => !TimeZoneData.ObsoleteWindowsZones.Contains(x.Key))
             .ToList();
@@ -307,7 +308,7 @@ public static class TZNames
         {
             return displayNames.ToOrderedDictionary(StringComparer.OrdinalIgnoreCase);
         }
-        
+
         var languageCodeParts = languageCode.Split('_', '-');
         var territoryCode = languageCodeParts.Length < 2 ? "001" : languageCodeParts[1];
         return displayNames.ToOrderedDictionary(
@@ -334,7 +335,7 @@ public static class TZNames
     public static ICollection<string> GetLanguageCodes(bool forDisplayNames)
     {
         var keys = forDisplayNames
-            ? (IEnumerable<string>) Data.DisplayNames.Keys
+            ? (IEnumerable<string>)Data.DisplayNames.Keys
             : Data.CldrLanguageData.Keys;
 
         return keys.OrderBy(x => x).ToList();
@@ -373,7 +374,7 @@ public static class TZNames
 
             if (key == null)
             {
-                var keys = forDisplayNames ? (IEnumerable<string>) Data.DisplayNames.Keys : Data.CldrLanguageData.Keys;
+                var keys = forDisplayNames ? (IEnumerable<string>)Data.DisplayNames.Keys : Data.CldrLanguageData.Keys;
                 key = keys.FirstOrDefault(x =>
                     x.Split('_')[0].Equals(languageCode.Split('-', '_')[0], StringComparison.OrdinalIgnoreCase));
 
@@ -438,7 +439,7 @@ public static class TZNames
 
         if (abbreviations && (timeZoneId == "Etc/GMT" || timeZoneId == "Etc/UTC"))
         {
-            return new TimeZoneValues {Generic = "UTC", Standard = "UTC", Daylight = "UTC"};
+            return new TimeZoneValues { Generic = "UTC", Standard = "UTC", Daylight = "UTC" };
         }
 
         var metaZone = GetMetazone(timeZoneId);
@@ -626,7 +627,8 @@ public static class TZNames
         }
 
         // last chance to make a generic name if it's missing
-        if (values.Generic == null) {
+        if (values.Generic == null)
+        {
             values.Generic = values.Standard;
         }
 

--- a/test/TimeZoneNames.Tests/TimeZoneNamesTest.cs
+++ b/test/TimeZoneNames.Tests/TimeZoneNamesTest.cs
@@ -23,16 +23,6 @@ public class TimeZoneNamesTest
     }
 
     [Fact]
-    public void Can_Get_Abbreviations_For_US_Pacific()
-    {
-        var abbreviations = TZNames.GetAbbreviationsForTimeZone("America/Los_Angeles", "en-US");
-
-        Assert.Equal("PT", abbreviations.Generic);
-        Assert.Equal("PST", abbreviations.Standard);
-        Assert.Equal("PDT", abbreviations.Daylight);
-    }
-
-    [Fact]
     public void Can_Get_French_Names_For_US_Pacific()
     {
         var names = TZNames.GetNamesForTimeZone("America/Los_Angeles", "fr-CA");
@@ -40,16 +30,6 @@ public class TimeZoneNamesTest
         Assert.Equal("heure du Pacifique", names.Generic);
         Assert.Equal("heure normale du Pacifique", names.Standard);
         Assert.Equal("heure avancée du Pacifique", names.Daylight);
-    }
-
-    [Fact]
-    public void Can_Get_French_Abbreviations_For_US_Pacific()
-    {
-        var abbreviations = TZNames.GetAbbreviationsForTimeZone("America/Los_Angeles", "fr-CA");
-
-        Assert.Equal("HP", abbreviations.Generic);
-        Assert.Equal("HNP", abbreviations.Standard);
-        Assert.Equal("HAP", abbreviations.Daylight);
     }
 
     [Fact]
@@ -74,26 +54,6 @@ public class TimeZoneNamesTest
     }
 
     [Fact]
-    public void Can_Get_Abbreviations_For_UK()
-    {
-        var abbreviations = TZNames.GetAbbreviationsForTimeZone("Europe/London", "en-US");
-
-        Assert.Null(abbreviations.Generic);
-        Assert.Equal("GMT", abbreviations.Standard);
-        Assert.Equal("BST", abbreviations.Daylight);
-    }
-
-    [Fact]
-    public void Can_Get_Abbreviations_For_Central_Europe()
-    {
-        var abbreviations = TZNames.GetAbbreviationsForTimeZone("Central European Standard Time", "en-US");
-
-        Assert.Equal("CET", abbreviations.Generic);
-        Assert.Equal("CET", abbreviations.Standard);
-        Assert.Equal("CEST", abbreviations.Daylight);
-    }
-
-    [Fact]
     public void Can_Get_Names_For_IE()
     {
         var names = TZNames.GetNamesForTimeZone("Europe/Dublin", "en-US");
@@ -101,16 +61,6 @@ public class TimeZoneNamesTest
         Assert.Equal("Ireland Time", names.Generic);
         Assert.Equal("Greenwich Mean Time", names.Standard);
         Assert.Equal("Irish Standard Time", names.Daylight);
-    }
-
-    [Fact]
-    public void Can_Get_Abbreviations_For_IE()
-    {
-        var abbreviations = TZNames.GetAbbreviationsForTimeZone("Europe/Dublin", "en-US");
-
-        Assert.Null(abbreviations.Generic);
-        Assert.Equal("GMT", abbreviations.Standard);
-        Assert.Equal("IST", abbreviations.Daylight);
     }
 
     [Fact]
@@ -124,16 +74,6 @@ public class TimeZoneNamesTest
     }
 
     [Fact]
-    public void Can_Get_Abbreviations_For_IN1()
-    {
-        var abbreviations = TZNames.GetAbbreviationsForTimeZone("Asia/Calcutta", "en-US");
-
-        Assert.Equal("IST", abbreviations.Generic);
-        Assert.Equal("IST", abbreviations.Standard);
-        Assert.Equal("IST", abbreviations.Daylight);
-    }
-
-    [Fact]
     public void Can_Get_Names_For_IN2()
     {
         var names = TZNames.GetNamesForTimeZone("Asia/Kolkata", "en-US");
@@ -141,16 +81,6 @@ public class TimeZoneNamesTest
         Assert.Equal("India Standard Time", names.Generic);
         Assert.Equal("India Standard Time", names.Standard);
         Assert.Equal("India Standard Time", names.Daylight);
-    }
-
-    [Fact]
-    public void Can_Get_Abbreviations_For_IN2()
-    {
-        var abbreviations = TZNames.GetAbbreviationsForTimeZone("Asia/Kolkata", "en-US");
-
-        Assert.Equal("IST", abbreviations.Generic);
-        Assert.Equal("IST", abbreviations.Standard);
-        Assert.Equal("IST", abbreviations.Daylight);
     }
 
     [Fact]
@@ -172,16 +102,6 @@ public class TimeZoneNamesTest
     //    Assert.Equal("Urumqi Standard Time", names.Standard);
     //    Assert.Equal("Urumqi Daylight Time", names.Daylight);
     //}
-
-    [Fact]
-    public void Can_Get_Abbreviations_For_Sao_Tome()
-    {
-        var abbreviations = TZNames.GetAbbreviationsForTimeZone("Sao Tome Standard Time", "en-GB");
-
-        Assert.Equal("GMT", abbreviations.Generic);
-        Assert.Equal("GMT", abbreviations.Standard);
-        Assert.Equal("GMT", abbreviations.Daylight);
-    }
 
     [Fact]
     public void Can_Get_Names_For_UTC()
@@ -223,16 +143,6 @@ public class TimeZoneNamesTest
         Assert.Equal("Eastern Time", names.Generic);
         Assert.Equal("Eastern Standard Time", names.Standard);
         Assert.Equal("Eastern Daylight Time", names.Daylight);
-    }
-
-    [Fact]
-    public void Can_Get_Abbreviations_For_Windows_Timezone()
-    {
-        var abbreviations = TZNames.GetAbbreviationsForTimeZone("AUS Eastern Standard Time", "en-US");
-
-        Assert.Equal("AET", abbreviations.Generic);
-        Assert.Equal("AEST", abbreviations.Standard);
-        Assert.Equal("AEDT", abbreviations.Daylight);
     }
 
     //[Fact]


### PR DESCRIPTION
Deprecate the `GetAbbreviationsForTimeZone` method, as many time zones do not have abbreviations, or do not have localized abbreviations in the CLDR source data.

Closes #91 